### PR TITLE
Persiste a busca por CEP no banco

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,5 +30,6 @@ end
 group :test do
   gem "capybara"
   gem "selenium-webdriver"
+  gem "shoulda-matchers"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,6 +316,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    shoulda-matchers (6.4.0)
+      activesupport (>= 5.2.0)
     solid_cache (1.0.6)
       activejob (>= 7.2)
       activerecord (>= 7.2)
@@ -412,6 +414,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rails-omakase
   selenium-webdriver
+  shoulda-matchers
   solid_cache
   solid_queue
   sqlite3 (>= 2.1)

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -25,9 +25,9 @@ class AddressesController < ApplicationController
 
   def save_address
     Address.create!(
-      cep: @address['cep'],
-      city: @address['city'],
-      state: @address['state']
+      cep: @address["cep"],
+      city: @address["city"],
+      state: @address["state"]
     )
   end
 end

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -4,6 +4,8 @@ class AddressesController < ApplicationController
   BASE_URL = "https://cep.awesomeapi.com.br/json/"
 
   def search
+    @most_searched_ceps = Address.most_searched
+
     uri = URI("#{BASE_URL}#{params[:cep]}")
     response = Net::HTTP.get_response(uri)
     @address = JSON.parse(response.body)

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -14,9 +14,20 @@ class AddressesController < ApplicationController
   private
 
   def address_response(response)
-    return @address if response.code == "200"
+    if response.code == "200"
+      save_address
+      return @address
+    end
 
     @error_message = @address["message"]
     @address = nil
+  end
+
+  def save_address
+    Address.create!(
+      cep: @address['cep'],
+      city: @address['city'],
+      state: @address['state']
+    )
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,2 @@
+class Address < ApplicationRecord
+end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,4 +1,11 @@
 class Address < ApplicationRecord
   validates :cep, :city, :state, presence: true
   validates :cep, format: { with: /\A\d{8}\z/, message: "CEP invalido" }
+
+  scope :most_searched, -> {
+    select("cep, COUNT(*) as cep_count")
+      .group(:cep)
+      .order("cep_count DESC")
+      .limit(3)
+  }
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,2 +1,4 @@
 class Address < ApplicationRecord
+  validates :cep, :city, :state, presence: true
+  validates :cep, format: { with: /\A\d{8}\z/, message: "CEP invalido" }
 end

--- a/app/views/addresses/search.html.erb
+++ b/app/views/addresses/search.html.erb
@@ -1,50 +1,66 @@
-<div class="flex justify-center h-screen mx-16">
-  <div class="flex justify-center flex-col pr-8 max-w-[280px]">
-    <h1 class="text-amber-700 font-bold text-4xl">Busca por CEP</h1>
-    <p class="text-amber-700">Digite um CEP para encontrar o endereço</p>
-    <%= form_with url: root_path, method: :get, local: true, class: "mt-10" do |form| %>
-      <div class="relative">
-        <%= form.text_field :cep,
-          value: params[:cep],
-          class: "p-3 pl-10 rounded-full w-full bg-white focus:outline-none focus:ring-2 focus:ring-orange-200 ",
-          placeholder: "00000-000"
-        %>
+<div class="flex justify-center flex-col h-screen mx-16">
+  <div class="flex">
+    <div class="flex justify-center flex-col pr-8 max-w-[280px]">
+      <h1 class="text-amber-700 font-bold text-4xl">Busca por CEP</h1>
+      <p class="text-amber-700">Digite um CEP para encontrar o endereço</p>
+      <%= form_with url: root_path, method: :get, local: true, class: "mt-10" do |form| %>
+        <div class="relative">
+          <%= form.text_field :cep,
+            value: params[:cep],
+            class: "p-3 pl-10 rounded-full w-full bg-white focus:outline-none focus:ring-2 focus:ring-orange-200 ",
+            placeholder: "00000-000"
+          %>
 
-        <svg xmlns="http://www.w3.org/2000/svg"
-          class="absolute left-3 top-1/2 transform -translate-y-1/2 h-6 w-6 text-orange-500"
-          fill="currentColor">
-          <path fill-rule="evenodd" d="m11.54 22.351.07.04.028.016a.76.76 0 0 0 .723 0l.028-.015.071-.041a16.975 16.975 0 0 0 1.144-.742 19.58 19.58 0 0 0 2.683-2.282c1.944-1.99 3.963-4.98 3.963-8.827a8.25 8.25 0 0 0-16.5 0c0 3.846 2.02 6.837 3.963 8.827a19.58 19.58 0 0 0 2.682 2.282 16.975 16.975 0 0 0 1.145.742ZM12 13.5a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z" clip-rule="evenodd" />
-        </svg>
-
-        <%= button_tag(type: "submit", name: nil, class: "absolute right-2 top-1/2 transform -translate-y-1/2 p-2 bg-orange-500 hover:bg-orange-600 rounded-full") do %>
           <svg xmlns="http://www.w3.org/2000/svg"
-          class="h-5 w-5"
-          fill="none" stroke="white">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            class="absolute left-3 top-1/2 transform -translate-y-1/2 h-6 w-6 text-orange-500"
+            fill="currentColor">
+            <path fill-rule="evenodd" d="m11.54 22.351.07.04.028.016a.76.76 0 0 0 .723 0l.028-.015.071-.041a16.975 16.975 0 0 0 1.144-.742 19.58 19.58 0 0 0 2.683-2.282c1.944-1.99 3.963-4.98 3.963-8.827a8.25 8.25 0 0 0-16.5 0c0 3.846 2.02 6.837 3.963 8.827a19.58 19.58 0 0 0 2.682 2.282 16.975 16.975 0 0 0 1.145.742ZM12 13.5a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z" clip-rule="evenodd" />
           </svg>
-        <% end %>
+
+          <%= button_tag(type: "submit", name: nil, class: "absolute right-2 top-1/2 transform -translate-y-1/2 p-2 bg-orange-500 hover:bg-orange-600 rounded-full") do %>
+            <svg xmlns="http://www.w3.org/2000/svg"
+            class="h-5 w-5"
+            fill="none" stroke="white">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+          <% end %>
+        </div>
+    <% end %>
+    </div>
+
+    <% if @address %>
+      <div class="bg-stone-50 flex justify-center flex-col my-auto p-14 rounded-3xl w-full">
+        <p class="text-orange-300 text-xs">CEP</p>
+        <p class="text-amber-700 pb-2"> <%= @address['cep'] %></p>
+        <p class="text-orange-300 text-xs">Endereço</p>
+        <p class="text-amber-700 pb-2"> <%= @address['address'] %></p>
+        <p class="text-orange-300 text-xs">Bairro</p>
+        <p class="text-amber-700 pb-2"> <%= @address['district'] %></p>
+        <p class="text-orange-300 text-xs">Cidade</p>
+        <p class="text-amber-700 pb-2"> <%= @address['city'] %></p>
+        <p class="text-orange-300 text-xs">Estado</p>
+        <p class="text-amber-700 pb-2"> <%= @address['state'] %></p>
+        <p class="text-orange-300 text-xs">DDD</p>
+        <p class="text-amber-700 pb-2"> <%= @address['ddd'] %></p>
       </div>
-  <% end %>
+    <% elsif @error_message && params[:cep].present? %>
+      <div class="bg-stone-50 flex justify-center flex-col my-auto p-14 rounded-3xl">
+        <p class="text-amber-700 p-6"><%= @error_message %></p>
+      </div>
+    <% end %>
   </div>
 
-  <% if @address %>
-    <div class="bg-stone-50 flex justify-center flex-col my-auto p-14 rounded-3xl">
-      <p class="text-orange-300 text-xs">CEP</p>
-      <p class="text-amber-700 pb-2"> <%= @address['cep'] %></p>
-      <p class="text-orange-300 text-xs">Endereço</p>
-      <p class="text-amber-700 pb-2"> <%= @address['address'] %></p>
-      <p class="text-orange-300 text-xs">Bairro</p>
-      <p class="text-amber-700 pb-2"> <%= @address['district'] %></p>
-      <p class="text-orange-300 text-xs">Cidade</p>
-      <p class="text-amber-700 pb-2"> <%= @address['city'] %></p>
-      <p class="text-orange-300 text-xs">Estado</p>
-      <p class="text-amber-700 pb-2"> <%= @address['state'] %></p>
-      <p class="text-orange-300 text-xs">DDD</p>
-      <p class="text-amber-700 pb-2"> <%= @address['ddd'] %></p>
+  <div class="mt-16 grid grid-cols-3">
+    <div class="">
+      <h2 class="text-center text-amber-700 font-bold text-2xl mb-2">CEPs mais buscados</h2>
+      <div class="text-center bg-stone-50 p-4 mx-10 rounded-2xl">
+        <% @most_searched_ceps.each do |address| %>
+          <div class="p-2">
+            <span class="text-amber-700"><%= address.cep %></span>
+            <span class="pl-2"><%= address.cep_count %> buscas</span>
+          </div>
+        <% end %>
+      </div>
     </div>
-  <% elsif @error_message && params[:cep].present? %>
-    <div class="bg-stone-50 flex justify-center flex-col my-auto p-14 rounded-3xl">
-      <p class="text-amber-700 p-6"><%= @error_message %></p>
-    </div>
-  <% end %>
+  </div>
 <div>

--- a/db/migrate/20250207021504_create_addresses.rb
+++ b/db/migrate/20250207021504_create_addresses.rb
@@ -1,0 +1,11 @@
+class CreateAddresses < ActiveRecord::Migration[8.0]
+  def change
+    create_table :addresses do |t|
+      t.string :cep
+      t.string :city
+      t.string :state
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,5 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 0) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_07_021504) do
+  create_table "addresses", force: :cascade do |t|
+    t.string "cep"
+    t.string "city"
+    t.string "state"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Address, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,5 +1,28 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Address, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:cep) }
+    it { is_expected.to validate_presence_of(:city) }
+    it { is_expected.to validate_presence_of(:state) }
+
+    context 'CEP' do
+      it 'is valid when format is correct' do
+        address = Address.new(cep: '12345678', city: 'São Paulo', state: 'SP')
+        expect(address).to be_valid
+      end
+
+      it 'is invalid when less than 8 digits' do
+        address = Address.new(cep: '1234567', city: 'São Paulo', state: 'SP')
+        expect(address).not_to be_valid
+      end
+
+      it 'is invalid when more than 8 digits' do
+        address = Address.new(cep: '123456789', city: 'São Paulo', state: 'SP')
+        expect(address).not_to be_valid
+      end
+    end
+  end
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -25,4 +25,28 @@ RSpec.describe Address, type: :model do
       end
     end
   end
+
+  describe 'scopes' do
+    context '.most_searched' do
+      before do
+        10.times { Address.create(cep: '10002020', city: "São Paulo", state: "SP") }
+        5.times { Address.create(cep: '51004014', city: "São Paulo", state: "SP") }
+        11.times { Address.create(cep: '11031502', city: "São Paulo", state: "SP") }
+        Address.create(cep: '00011122', city: "São Paulo", state: "SP")
+      end
+
+      it 'returns the 3 most searched ceps' do
+        most_searched = Address.most_searched
+
+        expect(most_searched.length).to eq(3)
+        expect(most_searched.first.cep).to eq('11031502')
+        expect(most_searched.first.cep_count).to eq(11)
+        expect(most_searched.second.cep).to eq('10002020')
+        expect(most_searched.second.cep_count).to eq(10)
+        expect(most_searched.third.cep).to eq('51004014')
+        expect(most_searched.third.cep_count).to eq(5)
+        expect(most_searched.pluck(:cep)).not_to include("00011122")
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,4 +67,10 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  Shoulda::Matchers.configure do |config|
+    config.integrate do |with|
+      with.test_framework :rspec
+      with.library :rails
+    end
+  end
 end


### PR DESCRIPTION
### Descrição
- Resolves https://github.com/crisaito/buscaPorCEP/issues/13
- Persiste busca por CEP no banco 

### Solução Proposta
- Persistencia de dados de cep, cidade e estado
- Adição de scope most_searched responsável por agrupar e ordenar os 3 maiores ceps pesquisados na app
- Adição da gem shoulda-matchers para auxiliar no teste de model
- Adição de card na view

### Screenshot
![image](https://github.com/user-attachments/assets/3b547ea8-8308-4d68-bd72-cb0c783e6b3b)
