### PR TITLE
Adiciona scope de busca por estados

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -4,14 +4,14 @@ class AddressesController < ApplicationController
   BASE_URL = "https://cep.awesomeapi.com.br/json/"
 
   def search
-    @most_searched_ceps = Address.most_searched
-    @most_searched_by_state = most_searched_by_state
-
     uri = URI("#{BASE_URL}#{params[:cep]}")
     response = Net::HTTP.get_response(uri)
     @address = JSON.parse(response.body)
 
     address_response(response)
+
+    @most_searched_ceps = Address.most_searched
+    @most_searched_by_state = most_searched_by_state
   end
 
   private

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -12,6 +12,7 @@ class AddressesController < ApplicationController
 
     @most_searched_ceps = Address.most_searched
     @most_searched_by_state = most_searched_by_state
+    @total_searched_by_state = total_searched_by_state
   end
 
   private
@@ -36,5 +37,11 @@ class AddressesController < ApplicationController
 
   def most_searched_by_state
     Address.searched_by_state.group_by(&:state).transform_values(&:first)
+  end
+
+  def total_searched_by_state
+    Address.searched_by_state.group_by(&:state).transform_values do |addresses|
+      addresses.sum(&:cep_count)
+    end
   end
 end

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -5,6 +5,7 @@ class AddressesController < ApplicationController
 
   def search
     @most_searched_ceps = Address.most_searched
+    @most_searched_by_state = Address.most_searched_by_state
 
     uri = URI("#{BASE_URL}#{params[:cep]}")
     response = Net::HTTP.get_response(uri)

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -5,7 +5,7 @@ class AddressesController < ApplicationController
 
   def search
     @most_searched_ceps = Address.most_searched
-    @most_searched_by_state = Address.most_searched_by_state
+    @most_searched_by_state = most_searched_by_state
 
     uri = URI("#{BASE_URL}#{params[:cep]}")
     response = Net::HTTP.get_response(uri)
@@ -32,5 +32,9 @@ class AddressesController < ApplicationController
       city: @address["city"],
       state: @address["state"]
     )
+  end
+
+  def most_searched_by_state
+    Address.searched_by_state.group_by(&:state).transform_values(&:first)
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -9,10 +9,9 @@ class Address < ApplicationRecord
       .limit(3)
   }
 
-  scope :most_searched_by_state, -> {
-    select("state, COUNT(*) as cep_count")
-      .group(:state)
-      .order("state, cep_count DESC")
-      .limit(3)
+  scope :searched_by_state, -> {
+    select("state, cep, COUNT(*) as cep_count")
+      .group(:state, :cep)
+      .order("cep_count DESC")
   }
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -12,6 +12,5 @@ class Address < ApplicationRecord
   scope :searched_by_state, -> {
     select("state, cep, COUNT(*) as cep_count")
       .group(:state, :cep)
-      .order("cep_count DESC")
   }
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -8,4 +8,11 @@ class Address < ApplicationRecord
       .order("cep_count DESC")
       .limit(3)
   }
+
+  scope :most_searched_by_state, -> {
+    select("state, COUNT(*) as cep_count")
+      .group(:state)
+      .order("state, cep_count DESC")
+      .limit(3)
+  }
 end

--- a/app/views/addresses/search.html.erb
+++ b/app/views/addresses/search.html.erb
@@ -50,10 +50,10 @@
     <% end %>
   </div>
 
-  <div class="mt-16 grid grid-cols-3">
-    <div class="">
-      <h2 class="text-center text-amber-700 font-bold text-2xl mb-2">CEPs mais buscados</h2>
-      <div class="text-center bg-stone-50 p-4 mx-10 rounded-2xl">
+  <div class="flex mt-16 grid grid-cols-3">
+    <div class="mx-4">
+      <h2 class=" h-14 text-center text-amber-700 font-bold text-lg mb-2">CEPs mais buscados</h2>
+      <div class="text-center bg-stone-50 p-4 rounded-2xl">
         <% @most_searched_ceps.each do |address| %>
           <div class="p-2">
             <span class="text-amber-700"><%= address.cep %></span>
@@ -62,12 +62,10 @@
         <% end %>
       </div>
     </div>
-  </div>
 
-  <div class="mt-16 grid grid-cols-3">
-    <div class="">
-      <h2 class="text-center text-amber-700 font-bold text-2xl mb-2">CEPs mais buscados por estado</h2>
-      <div class="text-center bg-stone-50 p-4 mx-10 rounded-2xl">
+    <div class="mx-4">
+      <h2 class=" h-14 text-center text-amber-700 font-bold text-lg mb-2">CEPs mais buscados por estado</h2>
+      <div class="text-center bg-stone-50 p-4 rounded-2xl">
         <% @most_searched_by_state.each do |address| %>
           <div class="p-2">
             <span class="text-amber-700"><%= address[1].cep %></span>
@@ -77,12 +75,10 @@
         <% end %>
       </div>
     </div>
-  </div>
 
-  <div class="mt-16 grid grid-cols-3">
-    <div class="">
-      <h2 class="text-center text-amber-700 font-bold text-2xl mb-2">Quantidades de CEPs buscados por estado</h2>
-      <div class="text-center bg-stone-50 p-4 mx-10 rounded-2xl">
+    <div class="mx-4">
+      <h2 class=" h-14 text-center text-amber-700 font-bold text-lg mb-2">Quantidades de CEPs buscados por estado</h2>
+      <div class="text-center bg-stone-50 p-4 rounded-2xl">
         <% @total_searched_by_state.each do |uf, total| %>
           <div class="p-2">
             <span class="text-amber-700"><%= uf %></span>

--- a/app/views/addresses/search.html.erb
+++ b/app/views/addresses/search.html.erb
@@ -63,4 +63,18 @@
       </div>
     </div>
   </div>
+
+  <div class="mt-16 grid grid-cols-3">
+  <div class="">
+    <h2 class="text-center text-amber-700 font-bold text-2xl mb-2">CEPs mais buscados</h2>
+    <div class="text-center bg-stone-50 p-4 mx-10 rounded-2xl">
+      <% @most_searched_by_state.each do |address| %>
+        <div class="p-2">
+          <span class="text-amber-700"><%= address.state %></span>
+          <span class="pl-2"><%= address.cep_count %> buscas</span>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
 <div>

--- a/app/views/addresses/search.html.erb
+++ b/app/views/addresses/search.html.erb
@@ -78,4 +78,18 @@
       </div>
     </div>
   </div>
+
+  <div class="mt-16 grid grid-cols-3">
+    <div class="">
+      <h2 class="text-center text-amber-700 font-bold text-2xl mb-2">Quantidades de CEPs buscados por estado</h2>
+      <div class="text-center bg-stone-50 p-4 mx-10 rounded-2xl">
+        <% @total_searched_by_state.each do |uf, total| %>
+          <div class="p-2">
+            <span class="text-amber-700"><%= uf %></span>
+            <span class="pl-2"><%= total %> buscas</span>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
 <div>

--- a/app/views/addresses/search.html.erb
+++ b/app/views/addresses/search.html.erb
@@ -1,4 +1,4 @@
-<div class="flex justify-center flex-col h-screen mx-16">
+<div class="flex justify-center flex-col m-40">
   <div class="flex">
     <div class="flex justify-center flex-col pr-8 max-w-[280px]">
       <h1 class="text-amber-700 font-bold text-4xl">Busca por CEP</h1>
@@ -65,16 +65,17 @@
   </div>
 
   <div class="mt-16 grid grid-cols-3">
-  <div class="">
-    <h2 class="text-center text-amber-700 font-bold text-2xl mb-2">CEPs mais buscados</h2>
-    <div class="text-center bg-stone-50 p-4 mx-10 rounded-2xl">
-      <% @most_searched_by_state.each do |address| %>
-        <div class="p-2">
-          <span class="text-amber-700"><%= address.state %></span>
-          <span class="pl-2"><%= address.cep_count %> buscas</span>
-        </div>
-      <% end %>
+    <div class="">
+      <h2 class="text-center text-amber-700 font-bold text-2xl mb-2">CEPs mais buscados por estado</h2>
+      <div class="text-center bg-stone-50 p-4 mx-10 rounded-2xl">
+        <% @most_searched_by_state.each do |address| %>
+          <div class="p-2">
+            <span class="text-amber-700"><%= address[1].cep %></span>
+            <span class="text-amber-700"><%= address[1].state %></span>
+            <span class="pl-2"><%= address[1].cep_count %> buscas</span>
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
-</div>
 <div>

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -27,15 +27,14 @@ RSpec.describe Address, type: :model do
   end
 
   describe 'scopes' do
+    before do
+      10.times { Address.create(cep: '10002020', city: "São Paulo", state: "SP") }
+      5.times { Address.create(cep: '51004014', city: "São Paulo", state: "SP") }
+      11.times { Address.create(cep: '11031502', city: "São Paulo", state: "SP") }
+      Address.create(cep: '00011122', city: "São Paulo", state: "SP")
+    end
     context '.most_searched' do
-      before do
-        10.times { Address.create(cep: '10002020', city: "São Paulo", state: "SP") }
-        5.times { Address.create(cep: '51004014', city: "São Paulo", state: "SP") }
-        11.times { Address.create(cep: '11031502', city: "São Paulo", state: "SP") }
-        Address.create(cep: '00011122', city: "São Paulo", state: "SP")
-      end
-
-      it 'returns the 3 most searched ceps' do
+      it 'returns the 3 most searched addresses' do
         most_searched = Address.most_searched
 
         expect(most_searched.length).to eq(3)
@@ -46,6 +45,23 @@ RSpec.describe Address, type: :model do
         expect(most_searched.third.cep).to eq('51004014')
         expect(most_searched.third.cep_count).to eq(5)
         expect(most_searched.pluck(:cep)).not_to include("00011122")
+      end
+    end
+
+    context '.searched_by_state' do
+      before do
+        4.times { Address.create(cep: '21090090', city: "Rio de Janeiro", state: "RJ") }
+        2.times { Address.create(cep: '21012121', city: "Rio de Janeiro", state: "RJ") }
+
+        3.times { Address.create(cep: '31090090', city: "Belo Horizonte", state: "MG") }
+      end
+
+      it 'returns all addresses grouped by state and cep' do
+        searched_by_state = Address.searched_by_state
+
+        expect(searched_by_state.count { |address| address.state == "SP" }).to eq(4)
+        expect(searched_by_state.count { |address| address.state == "RJ" }).to eq(2)
+        expect(searched_by_state.count { |address| address.state == "MG" }).to eq(1)
       end
     end
   end


### PR DESCRIPTION
### Descrição
- Adiciona ceps mais buscados por estado
- Adiciona quantidade de ceps buscados por estado

### Solução Proposta
- Adição de scope most_searched_by_state responsável por agrupar addresses por state e ceps
- Adição de cards na view

### Screenshot
![image](https://github.com/user-attachments/assets/5d9735d0-c873-4f2b-88d8-9a6829abdd8b)
